### PR TITLE
Fix build error on recent compilers

### DIFF
--- a/src/parser/bracket_notation_parser.h
+++ b/src/parser/bracket_notation_parser.h
@@ -48,6 +48,7 @@
 #include "node.h"
 #include "string_label.h"
 
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <string>


### PR DESCRIPTION
Recent versions of clang (14.0.6) and gcc (12.2.0) can't build the project due to `strpbrk` and `strcmp` being undeclared (see below). Including the `cstring` header file fixes this.

clang build error:
```
In file included from /home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc:28:
In file included from /home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser.h:120:
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:26: error: use of undeclared identifier 'strpbrk'
  for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
                         ^
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:77: error: use of undeclared identifier 'strpbrk'
  for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
                                                                            ^
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc:86:12: error: no member named 'strcmp' in namespace 'std'
  if (std::strcmp(argv[3], "lgm") == 0) {
      ~~~~~^
2 warnings and 3 errors generated.
make[2]: *** [src/command_line/CMakeFiles/ted.dir/build.make:76: src/command_line/CMakeFiles/ted.dir/main.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1140: src/command_line/CMakeFiles/ted.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```

gcc build error:
```
In file included from /home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser.h:120,
                 from /home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc:28:
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h: In member function ‘std::vector<std::__cxx11::basic_string<char> > parser::BracketNotationParser<Label>::get_tokens(const std::string&)’:
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:26: error: there are no arguments to ‘strpbrk’ that depend on a template parameter, so a declaration of ‘strpbrk’ must be available [-fpermissive]
  132 |   for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
      |                          ^~~~~~~
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:26: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:77: error: there are no arguments to ‘strpbrk’ that depend on a template parameter, so a declaration of ‘strpbrk’ must be available [-fpermissive]
  132 |   for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
      |                                                                             ^~~~~~~
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc: In function ‘int main(int, char**)’:
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc:86:12: error: ‘strcmp’ is not a member of ‘std’
   86 |   if (std::strcmp(argv[3], "lgm") == 0) {
      |            ^~~~~~
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h: In instantiation of ‘std::vector<std::__cxx11::basic_string<char> > parser::BracketNotationParser<Label>::get_tokens(const std::string&) [with Label = label::StringLabel; std::string = std::__cxx11::basic_string<char>]’:
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:35:37:   required from ‘node::Node<Label> parser::BracketNotationParser<Label>::parse_single(const std::string&) [with Label = label::StringLabel; std::string = std::__cxx11::basic_string<char>]’
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/command_line/main.cc:69:57:   required from here
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:33: error: ‘strpbrk’ was not declared in this scope
  132 |   for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
      |                          ~~~~~~~^~~~~~~~~~~~~~~~~~~~~
/home/martin/Documents/Uni/Master_Informatik_Salzburg/22WS/Masterarbeit/Unterlagen/Source_Code/tree-similarity/src/parser/bracket_notation_parser_impl.h:132:84: error: ‘strpbrk’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  132 |   for(const char* iter = strpbrk(next_begin, s_elems); iter != NULL; iter = strpbrk(next_begin, s_elems)) {
      |                                                                             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~
make[2]: *** [src/command_line/CMakeFiles/ted.dir/build.make:76: src/command_line/CMakeFiles/ted.dir/main.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1140: src/command_line/CMakeFiles/ted.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```