### PR TITLE
Support trees as strings to the command line (Fixes issue #22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ CMakeScripts
 Makefile
 cmake_install.cmake
 install_manifest.txt
+
+#Ignore Visual Studio files
+.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,20 @@ endif()
 # Compiler flags.
 # MUST be declared after project().
 # TODO: Explain the flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -Wall -Wextra -Wpedantic")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -Wall -Wextra -Wpedantic")
+#Define CXX standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+#Add flags applicable to all compilers
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+
+#Add compiler specific flags
+if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GCC detected, adding compile flags")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wpedantic")
+endif(CMAKE_COMPILER_IS_GNUCXX)
 
 # It's possible to set compiler-specific flags.
 #if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ Execute ``make test`` to run all tests (currently there are only correctness tes
 
 In the ``build`` directory you find the binary ``ted`` that executes the algorithms from command line. **Currently there is no help or documentation for this binary.**
 
+## Usage
+
+The ``command_line`` program allows you to measure the Tree Edit Distance between 2 tree structures (using the Bracket Notation Format) using APTED.
+
+The trees can be passed as string arguments:
+```
+./ted string {x{a}{b}} {x{a}{c}}
+```
+
+or read from files:
+```
+./ted file treeA.txt treeB.txt
+```
+
+
 ## Generating documentation
 
 Install [Doxygen](http://www.stack.nl/~dimitri/doxygen/) for generating the documentation.

--- a/src/command_line/main.cc
+++ b/src/command_line/main.cc
@@ -20,8 +20,9 @@
 // SOFTWARE.
 
 #include <iostream>
-#include <sys/time.h>
-#include <sys/resource.h>
+// These are linux only headers, not available on Windows
+//#include <sys/time.h>
+//#include <sys/resource.h>
 #include "node.h"
 #include "string_label.h"
 #include "unit_cost_model.h"
@@ -36,12 +37,13 @@ int main(int argc, char** argv) {
   using CostModelLD = cost_model::UnitCostModelLD<Label>;
   using LabelDictionary = label::LabelDictionary<Label>;
 
-  // Runtime measurement variables (rusage).
-  rusage before_rusage;
-  rusage after_rusage;
-  timeval runtime_utime;
-  timeval runtime_stime;
-  unsigned int runtime;
+  /////// Runtime measurement should be limited to tests, and use portable libraries if available
+  //// Runtime measurement variables (rusage).
+  //rusage before_rusage;
+  //rusage after_rusage;
+  //timeval runtime_utime;
+  //timeval runtime_stime;
+  //unsigned int runtime;
 
   // Verify parameters.
   if (argc != 5) {
@@ -58,7 +60,7 @@ int main(int argc, char** argv) {
   // Verify the input format before parsing.
   
 
-  getrusage(RUSAGE_SELF, &before_rusage);
+  //getrusage(RUSAGE_SELF, &before_rusage);
   std::ifstream tree_file(argv[1]);
   std::string tree_string;
   std::getline(tree_file, tree_string);
@@ -76,16 +78,16 @@ int main(int argc, char** argv) {
   }
   const node::Node<Label> destination_tree = bnp.parse_single(tree_string);
   tree_file.close();
-  getrusage(RUSAGE_SELF, &after_rusage);
+  /*getrusage(RUSAGE_SELF, &after_rusage);
   timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
   timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
-  runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 +
-      runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;
-  std::cout << runtime << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
+  runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;*/
+  //std::cout << runtime << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
+  std::cout << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
 
   if (std::strcmp(argv[3], "lgm") == 0) {
     int k = std::stoi(argv[4]);
-    getrusage(RUSAGE_SELF, &before_rusage);
+    //getrusage(RUSAGE_SELF, &before_rusage);
     LabelDictionary ld;
     CostModelLD ucm(ld);
     ted_ub::LGMTreeIndex<CostModelLD, node::TreeIndexLGM> lgm_algorithm(ucm);
@@ -95,13 +97,12 @@ int main(int argc, char** argv) {
     node::index_tree(ti2, destination_tree, ld, ucm);
     lgm_algorithm.init(ti2);
     std::cout << lgm_algorithm.ted_k(ti1, ti2, k);
-    getrusage(RUSAGE_SELF, &after_rusage);
+    //getrusage(RUSAGE_SELF, &after_rusage);
     std::cout << " " << lgm_algorithm.get_subproblem_count();
-    timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
-    timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
-    runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 +
-        runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;
-    std::cout << " " << runtime << std::endl;
+    //timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
+    //timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
+    //runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;
+    //std::cout << " " << runtime << std::endl;
   }
 
   return 0;

--- a/src/command_line/main.cc
+++ b/src/command_line/main.cc
@@ -20,41 +20,24 @@
 // SOFTWARE.
 
 #include <iostream>
-// These are linux only headers, not available on Windows
-//#include <sys/time.h>
-//#include <sys/resource.h>
 #include "node.h"
 #include "string_label.h"
 #include "unit_cost_model.h"
 #include "bracket_notation_parser.h"
-#include "lgm_tree_index.h"
+#include "apted_tree_index.h"
 
 /// Simple command-line tool for executing Tree Edit Distance.
-
 int main(int argc, char** argv) {
 
   using Label = label::StringLabel;
   using CostModelLD = cost_model::UnitCostModelLD<Label>;
   using LabelDictionary = label::LabelDictionary<Label>;
 
-  /////// Runtime measurement should be limited to tests, and use portable libraries if available
-  //// Runtime measurement variables (rusage).
-  //rusage before_rusage;
-  //rusage after_rusage;
-  //timeval runtime_utime;
-  //timeval runtime_stime;
-  //unsigned int runtime;
-
   // Verify parameters.
-  if (argc != 6) {
-    std::cerr << "Incorrect number of parameters. Sample usage: ./ted string {x{a}} {x{b}} lgm 1" << std::endl;
+  if (argc != 4) {
+    std::cerr << "Incorrect number of parameters. Sample usage: ./ted string {x{a}} {x{b}}" << std::endl;
     return -1;
   }
-
-  // NOTE: Trees passed as command-line arguments must be sorrounded with ''.
-
-  //std::cout << "Source tree: " << argv[2] << std::endl;
-  //std::cout << "Destination tree: " << argv[3] << std::endl;
 
   std::string source_tree_string;
   std::string dest_tree_string;
@@ -66,9 +49,7 @@ int main(int argc, char** argv) {
     source_tree_string = argv[2];
     dest_tree_string = argv[3];
   } else if (std::strcmp(argv[1], "file") == 0) {
-    // getrusage(RUSAGE_SELF, &before_rusage);
     std::ifstream tree_file(argv[2]);
-    //std::string tree_string;
     std::getline(tree_file, source_tree_string);
     tree_file.close();
 
@@ -92,34 +73,17 @@ int main(int argc, char** argv) {
   }
   const node::Node<Label> destination_tree = bnp.parse_single(dest_tree_string);
 
-  /*getrusage(RUSAGE_SELF, &after_rusage);
-  timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
-  timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
-  runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;*/
-  //std::cout << runtime << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
   std::cout << "Size of source tree:" << source_tree.get_tree_size() << std::endl;
   std::cout << "Size of destination tree:" << destination_tree.get_tree_size() << std::endl;
 
-  if (std::strcmp(argv[4], "lgm") == 0) {
-    int k = std::stoi(argv[5]);
-    //getrusage(RUSAGE_SELF, &before_rusage);
-    LabelDictionary ld;
-    CostModelLD ucm(ld);
-    ted_ub::LGMTreeIndex<CostModelLD, node::TreeIndexLGM> lgm_algorithm(ucm);
-    node::TreeIndexLGM ti1;
-    node::TreeIndexLGM ti2;
-    node::index_tree(ti1, source_tree, ld, ucm);
-    node::index_tree(ti2, destination_tree, ld, ucm);
-    lgm_algorithm.init(ti2);
-    std::cout << "Distance TED_K:" << lgm_algorithm.ted_k(ti1, ti2, k) << std::endl;
-    std::cout << "Distance TED:" << lgm_algorithm.ted(ti1, ti2) << std::endl;
-    //getrusage(RUSAGE_SELF, &after_rusage);
-    std::cout << "Number of subproblems:" << lgm_algorithm.get_subproblem_count() << std::endl;
-    //timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
-    //timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
-    //runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;
-    //std::cout << " " << runtime << std::endl;
-  }
+  LabelDictionary ld;
+  CostModelLD ucm(ld);
+  ted::APTEDTreeIndex<CostModelLD, node::TreeIndexAPTED> apted_algorithm(ucm);
+  node::TreeIndexAPTED ti1;
+  node::TreeIndexAPTED ti2;
+  node::index_tree(ti1, source_tree, ld, ucm);
+  node::index_tree(ti2, destination_tree, ld, ucm);
+  std::cout << "Distance TED:" << apted_algorithm.ted(ti1, ti2) << std::endl;
 
   return 0;
 }

--- a/src/command_line/main.cc
+++ b/src/command_line/main.cc
@@ -28,6 +28,7 @@
 #include "unit_cost_model.h"
 #include "bracket_notation_parser.h"
 #include "lgm_tree_index.h"
+#include "apted_tree_index.h"
 
 /// Simple command-line tool for executing Tree Edit Distance.
 
@@ -46,59 +47,76 @@ int main(int argc, char** argv) {
   //unsigned int runtime;
 
   // Verify parameters.
-  if (argc != 5) {
-    std::cerr << "Incorrect number of parameters." << std::endl;
+  if (argc != 6) {
+    std::cerr << "Incorrect number of parameters. Sample usage: ./ted string {x{a}} {x{b}} lgm 1" << std::endl;
     return -1;
   }
 
   // NOTE: Trees passed as command-line arguments must be sorrounded with ''.
 
-  // std::cout << "Source tree: " << argv[1] << std::endl;
-  // std::cout << "Destination tree: " << argv[2] << std::endl;
+  //std::cout << "Source tree: " << argv[2] << std::endl;
+  //std::cout << "Destination tree: " << argv[3] << std::endl;
+
+  std::string source_tree_string;
+  std::string dest_tree_string;
 
   parser::BracketNotationParser<Label> bnp;
   // Verify the input format before parsing.
-  
 
-  //getrusage(RUSAGE_SELF, &before_rusage);
-  std::ifstream tree_file(argv[1]);
-  std::string tree_string;
-  std::getline(tree_file, tree_string);
-  if (!bnp.validate_input(tree_string)) {
+  if (std::strcmp(argv[1], "string") == 0) {
+    source_tree_string = argv[2];
+    dest_tree_string = argv[3];
+  } else if (std::strcmp(argv[1], "file") == 0) {
+    // getrusage(RUSAGE_SELF, &before_rusage);
+    std::ifstream tree_file(argv[2]);
+    //std::string tree_string;
+    std::getline(tree_file, source_tree_string);
+    tree_file.close();
+
+    tree_file = std::ifstream(argv[3]);
+    std::getline(tree_file, dest_tree_string);
+    tree_file.close();
+  } else {
+    std::cerr << "Incorrect input format. Use either string or file." << std::endl;
+    return -1;
+  }
+  
+  if (!bnp.validate_input(source_tree_string)) {
     std::cerr << "Incorrect format of source tree. Is the number of opening and closing brackets equal?" << std::endl;
     return -1;
   }
-  const node::Node<Label> source_tree = bnp.parse_single(tree_string);
-  tree_file.close();
-  tree_file = std::ifstream(argv[2]);
-  std::getline(tree_file, tree_string);
-  if (!bnp.validate_input(tree_string)) {
-    std::cerr << "Incorrect format of source tree. Is the number of opening and closing brackets equal?" << std::endl;
+  const node::Node<Label> source_tree = bnp.parse_single(source_tree_string);
+
+  if (!bnp.validate_input(dest_tree_string)) {
+    std::cerr << "Incorrect format of destination tree. Is the number of opening and closing brackets equal?" << std::endl;
     return -1;
   }
-  const node::Node<Label> destination_tree = bnp.parse_single(tree_string);
-  tree_file.close();
+  const node::Node<Label> destination_tree = bnp.parse_single(dest_tree_string);
+
   /*getrusage(RUSAGE_SELF, &after_rusage);
   timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
   timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
   runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;*/
   //std::cout << runtime << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
-  std::cout << " " << source_tree.get_tree_size() << " " << destination_tree.get_tree_size() << " ";
+  std::cout << "Size of source tree:" << source_tree.get_tree_size() << std::endl;
+  std::cout << "Size of destination tree:" << destination_tree.get_tree_size() << std::endl;
 
-  if (std::strcmp(argv[3], "lgm") == 0) {
-    int k = std::stoi(argv[4]);
+  if (std::strcmp(argv[4], "lgm") == 0) {
+    int k = std::stoi(argv[5]);
     //getrusage(RUSAGE_SELF, &before_rusage);
     LabelDictionary ld;
     CostModelLD ucm(ld);
     ted_ub::LGMTreeIndex<CostModelLD, node::TreeIndexLGM> lgm_algorithm(ucm);
+    ted::APTEDTreeIndex<CostModelLD, node::TreeIndexLGM> apted_algorithm(ucm);
     node::TreeIndexLGM ti1;
     node::TreeIndexLGM ti2;
     node::index_tree(ti1, source_tree, ld, ucm);
     node::index_tree(ti2, destination_tree, ld, ucm);
     lgm_algorithm.init(ti2);
-    std::cout << lgm_algorithm.ted_k(ti1, ti2, k);
+    std::cout << "Distance TED_K:" << lgm_algorithm.ted_k(ti1, ti2, k) << std::endl;
+    std::cout << "Distance TED:" << lgm_algorithm.ted(ti1, ti2) << std::endl;
     //getrusage(RUSAGE_SELF, &after_rusage);
-    std::cout << " " << lgm_algorithm.get_subproblem_count();
+    std::cout << "Number of subproblems:" << lgm_algorithm.get_subproblem_count() << std::endl;
     //timersub(&after_rusage.ru_utime, &before_rusage.ru_utime, &runtime_utime);
     //timersub(&after_rusage.ru_stime, &before_rusage.ru_stime, &runtime_stime);
     //runtime = runtime_utime.tv_usec + runtime_utime.tv_sec * 1000000 + runtime_stime.tv_usec + runtime_stime.tv_sec * 1000000;

--- a/src/command_line/main.cc
+++ b/src/command_line/main.cc
@@ -28,7 +28,6 @@
 #include "unit_cost_model.h"
 #include "bracket_notation_parser.h"
 #include "lgm_tree_index.h"
-#include "apted_tree_index.h"
 
 /// Simple command-line tool for executing Tree Edit Distance.
 
@@ -107,7 +106,6 @@ int main(int argc, char** argv) {
     LabelDictionary ld;
     CostModelLD ucm(ld);
     ted_ub::LGMTreeIndex<CostModelLD, node::TreeIndexLGM> lgm_algorithm(ucm);
-    ted::APTEDTreeIndex<CostModelLD, node::TreeIndexLGM> apted_algorithm(ucm);
     node::TreeIndexLGM ti1;
     node::TreeIndexLGM ti2;
     node::index_tree(ti1, source_tree, ld, ucm);


### PR DESCRIPTION
I had to make some changes to the compiler flags to make it compile on Windows using MSVC, then realized that passing trees as string directly wasn't supported, so I added an argument to specify how the trees are being passed, using the first argument with `string` or `file`.

If you would prefer not passing an additional argument, it should be possible to automatically detect the type of input by testing them with `BracketNotationParser`.