### PR TITLE
Install only header files (no need for the command line program)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,17 @@
 # Let CMake know about subdirectories.
 add_subdirectory(command_line/)
 
-install(
-  DIRECTORY .
+install( DIRECTORY
+  node
+  label
+  cost_model
+  ted
+  data_structures
+  parser
+  lookup
+  join
+  tree_generator
+  ted_ub
+  ted_lb
+  json
   DESTINATION include/tree-similiarity)


### PR DESCRIPTION
vcpkg maintainers requested some changes before approving the PR (to include tree-similarity in vcpkg). See the discussion here:
https://github.com/microsoft/vcpkg/pull/30901#issuecomment-1527052949

Essentially, the installation of the library needs to exclude the `command_line` program.

Also, vcpkg supports semantic versioning too. My PR currently uses string versioning since there is a letter (`v`) in the tag (`v0.1.0`). I will need to update the commit reference once this PR is merged so that vcpkg can download the latest version. We could take this opportunity to change string versioning to semver before the PR gets merged. Simply create a new tag (`0.1.1`, without the preceeding `v`) once the PR is merged